### PR TITLE
Changes to sdl field of _service object to make it compliant with the…

### DIFF
--- a/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -11,10 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 // SDL is returned without _entity and _service queries
-const val FEDERATED_SERVICE_SDL = """schema {
-  query: Query
-}
-
+const val FEDERATED_SERVICE_SDL = """
 interface Product @extends @key(fields : "id") {
   id: String! @external
   reviews: [Review!]!
@@ -26,9 +23,6 @@ type Book implements Product @extends @key(fields : "id") {
   reviews: [Review!]!
   shippingCost: String! @requires(fields : "weight")
   weight: Float! @external
-}
-
-type Query {
 }
 
 type Review {
@@ -69,6 +63,6 @@ class ServiceQueryResolverTest {
         val queryResult = data["_service"] as? Map<*, *>
         assertNotNull(queryResult)
         val sdl = queryResult["sdl"] as? String
-        assertEquals(FEDERATED_SERVICE_SDL, sdl)
+        assertEquals(FEDERATED_SERVICE_SDL.trim(), sdl)
     }
 }


### PR DESCRIPTION
…… (#304)

* Changes to sdl field of _service object to make it compliant with the federation specification

- if the Query type is present, it should have the @extends directive, since it extends the query type
- the default schema definition should not be included in the sdl
- empty queries should not be present in the SDL